### PR TITLE
Add get-dotnet-version action and Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Full version tag to release, e.g. v4.5 or v4.5.2'
+        type: string
+        required: true
+      prerelease:
+        description: 'Mark the GitHub Release as a prerelease'
+        type: boolean
+        required: false
+        default: false
+      draft:
+        description: 'Create the GitHub Release as a draft'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Validate tag and derive major tag
+        id: vars
+        shell: bash
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){1,2}$ ]]; then
+            echo "::error::Invalid tag '$TAG'. Expected format vMAJOR.MINOR or vMAJOR.MINOR.PATCH (e.g. v4.5 or v4.5.2)."
+            exit 1
+          fi
+          MAJOR_TAG="v$(echo "${TAG#v}" | cut -d. -f1)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "major_tag=$MAJOR_TAG" >> "$GITHUB_OUTPUT"
+          echo "Releasing $TAG, moving major tag $MAJOR_TAG"
+
+      - name: Configure git user
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create version tag
+        shell: bash
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+          SHA: ${{ github.sha }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag '$TAG' already exists. Version tags are immutable and will not be overwritten."
+            exit 1
+          fi
+          git tag -a "$TAG" -m "Release $TAG" "$SHA"
+          git push origin "refs/tags/$TAG"
+          echo "Created and pushed version tag $TAG at $SHA"
+
+      - name: Move major tag
+        shell: bash
+        env:
+          MAJOR_TAG: ${{ steps.vars.outputs.major_tag }}
+          TAG: ${{ steps.vars.outputs.tag }}
+          SHA: ${{ github.sha }}
+        run: |
+          # The major tag is a moving pointer to the latest release in its line.
+          git tag -d "$MAJOR_TAG" 2>/dev/null || true
+          git push origin ":refs/tags/$MAJOR_TAG" 2>/dev/null || true
+          git tag -a "$MAJOR_TAG" -m "Update $MAJOR_TAG to $TAG" "$SHA"
+          git push --force origin "refs/tags/$MAJOR_TAG"
+          echo "Moved major tag $MAJOR_TAG to $SHA"
+
+      - name: Create GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.vars.outputs.tag }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          DRAFT: ${{ inputs.draft }}
+        run: |
+          ARGS=("$TAG" --title "$TAG" --generate-notes --target "${{ github.sha }}")
+          if [[ "$PRERELEASE" == "true" ]]; then
+            ARGS+=(--prerelease)
+          fi
+          if [[ "$DRAFT" == "true" ]]; then
+            ARGS+=(--draft)
+          fi
+          gh release create "${ARGS[@]}"
+
+      - name: Summary
+        shell: bash
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+          MAJOR_TAG: ${{ steps.vars.outputs.major_tag }}
+          SHA: ${{ github.sha }}
+        run: |
+          echo "::notice::Released $TAG, moved $MAJOR_TAG to $SHA"

--- a/README.md
+++ b/README.md
@@ -123,3 +123,71 @@ The output would be:
 ```
 steps.set-version-number.outputs.version - 2.1.50
 ```
+
+## Get .NET Version
+
+Derives a package version from MSBuild props where **the version is stated, not inferred**:
+`Major.Minor` comes from `VersionPrefix`, and the patch is the number of commits **since that
+version line last changed** (so unrelated edits to the props file don't reset it). Set
+`VersionSuffix` for a prerelease line. Internally uses `get-version-number-from-project` for
+Major/Minor. Requires a full-history checkout (`fetch-depth: 0`) and the .NET SDK on the runner.
+
+### Example
+
+Given `Directory.Build.props`:
+
+```xml
+<PropertyGroup>
+  <VersionPrefix>4.0</VersionPrefix>
+  <!-- optional, for a prerelease line: -->
+  <!-- <VersionSuffix>beta</VersionSuffix> -->
+</PropertyGroup>
+```
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0          # required: full history for the commit count
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.x
+    - name: Get version
+      id: version
+      uses: andrewmclachlan/actions/get-dotnet-version@v4
+      with:
+        project: 'Directory.Build.props'   # optional, this is the default
+    - name: Build
+      run: dotnet build --p:Version=${{ steps.version.outputs.version }} --p:AssemblyVersion=${{ steps.version.outputs.assembly-version }} --p:FileVersion=${{ steps.version.outputs.file-version }}
+```
+
+Outputs (17 commits since the `VersionPrefix` line changed):
+
+```
+steps.version.outputs.version          - 4.0.17   (5.0.0-beta.17 with VersionSuffix=beta)
+steps.version.outputs.assembly-version - 4.0.0.0
+steps.version.outputs.file-version     - 4.0.17.0
+steps.version.outputs.patch            - 17
+```
+
+## Releasing
+
+This repo publishes reusable actions that consumers reference by tag (e.g. `andrewmclachlan/actions/set-version-number@v4`). Releases follow the **moving major tag** convention: alongside an immutable full version tag (`v4.5`, `v4.5.2`), a `v<MAJOR>` tag (`v4`) is kept pointing at the latest release in that major line. Consumers pin `@v4` and automatically pick up the newest `v4.x`.
+
+To cut a release:
+
+1. Go to **Actions → Release → Run workflow**.
+2. Select the branch/ref you want to release from (the workflow tags whatever commit you dispatch against).
+3. Enter the full version `tag`, e.g. `v4.5` or `v4.5.2` (must match `vMAJOR.MINOR` or `vMAJOR.MINOR.PATCH`).
+4. Optionally tick `prerelease` and/or `draft`.
+5. Run it.
+
+The workflow will:
+
+- Validate the tag format and derive the major tag (`v4.5` → `v4`).
+- Create the annotated full version tag at the dispatched commit and push it. It **fails** if that exact version tag already exists (version tags are immutable).
+- Delete and recreate the major tag `v<MAJOR>` at the same commit, force-pushing it so `@v4` moves forward.
+- Create a GitHub Release for the version tag with auto-generated notes, honouring the `prerelease`/`draft` inputs.

--- a/get-dotnet-version/GetVersion.ps1
+++ b/get-dotnet-version/GetVersion.ps1
@@ -1,0 +1,41 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [string]$Project,
+    [Parameter(Mandatory = $true)]
+    [string]$Major,
+    [Parameter(Mandatory = $true)]
+    [string]$Minor
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Prerelease suffix (e.g. beta) is optional; msbuild returns an empty string when it is absent.
+$suffix = (dotnet msbuild $Project -getProperty:VersionSuffix).Trim()
+
+# Patch = commits since the version LINE last changed. -G'<Version' matches only commits whose diff
+# touched a <VersionPrefix>/<VersionSuffix> line, so other edits to the props file are ignored.
+$set = (git log -1 --format=%H '-G<Version' -- $Project).Trim()
+if ($set) {
+    $count = (git rev-list --count "$set..HEAD").Trim()
+}
+else {
+    $count = (git rev-list --count HEAD).Trim()
+}
+
+if ($suffix) {
+    $version = "$Major.$Minor.0-$suffix.$count"
+}
+else {
+    $version = "$Major.$Minor.$count"
+}
+$assemblyVersion = "$Major.0.0.0"
+$fileVersion = "$Major.$Minor.$count.0"
+
+Write-Output "Version is $version (assembly $assemblyVersion, file $fileVersion)"
+
+"version=$version" >> $Env:GITHUB_OUTPUT
+"assembly-version=$assemblyVersion" >> $Env:GITHUB_OUTPUT
+"file-version=$fileVersion" >> $Env:GITHUB_OUTPUT
+"patch=$count" >> $Env:GITHUB_OUTPUT
+
+Write-Output "::notice::Version $version (assembly $assemblyVersion)"

--- a/get-dotnet-version/action.yml
+++ b/get-dotnet-version/action.yml
@@ -1,0 +1,37 @@
+name: 'Get .NET version'
+author: 'Andrew McLachlan'
+description: >-
+  Derive the package version from MSBuild props: Major.Minor comes from VersionPrefix,
+  the patch is the number of commits since that version line last changed (so unrelated
+  edits to the props file do not reset it). Set VersionSuffix for a prerelease line.
+  Requires a full-history checkout (fetch-depth: 0) and the .NET SDK on the runner.
+  Outputs Version, AssemblyVersion (Major.0.0.0) and FileVersion.
+inputs:
+  project:
+    description: 'MSBuild file that declares VersionPrefix (and optionally VersionSuffix)'
+    default: 'Directory.Build.props'
+    required: false
+runs:
+  using: composite
+  steps:
+    - id: major-minor
+      uses: AndrewMcLachlan/Actions/get-version-number-from-project@v4
+      with:
+        project: ${{ inputs.project }}
+        version-property-name: VersionPrefix
+    - id: assemble
+      shell: pwsh
+      run: ${{ github.action_path }}/GetVersion.ps1 -Project '${{ inputs.project }}' -Major '${{ steps.major-minor.outputs.major }}' -Minor '${{ steps.major-minor.outputs.minor }}'
+outputs:
+  version:
+    description: 'Full package version, e.g. 4.0.17 (stable) or 5.0.0-beta.4 (prerelease)'
+    value: ${{ steps.assemble.outputs.version }}
+  assembly-version:
+    description: 'Assembly version, pinned to Major.0.0.0'
+    value: ${{ steps.assemble.outputs.assembly-version }}
+  file-version:
+    description: 'File version, Major.Minor.patch.0'
+    value: ${{ steps.assemble.outputs.file-version }}
+  patch:
+    description: 'The computed patch (commit count since the version line changed)'
+    value: ${{ steps.assemble.outputs.patch }}


### PR DESCRIPTION
Two additions to support ASM's (and later MooApp's) new **stated-version** scheme.

## `get-dotnet-version`
Derives a package version from MSBuild props, no GitVersion:
- `Major.Minor` from `<VersionPrefix>` — internally via the existing `get-version-number-from-project`.
- **patch = commits since the version line last changed** (`git log -G'<Version'` + `git rev-list --count`), so unrelated edits to the props file don't bump it.
- `<VersionSuffix>` → prerelease (`5.0.0-beta.N`).
- Outputs `version`, `assembly-version` (`Major.0.0.0`), `file-version`, `patch`.
- Needs `fetch-depth: 0` and the .NET SDK on the runner. Verified locally against ASM: `4.0.0` / `4.0.0.0` / `4.0.0.0`.

## `release.yml`
`workflow_dispatch` to cut a release: enter a full tag (`v4.5`), it tags the dispatched commit, **moves the `v4` major tag** to it (the convention consumers already pin), and creates a GitHub Release with generated notes. Version tags are immutable (fails if the exact tag exists); the major tag moves.

README updated for both.

## Note
`get-dotnet-version` references sibling actions at `@v4`. After merging, cut a release (**Actions → Release**, e.g. `v4.5`) so `v4` includes this action — then consumers referencing `get-dotnet-version@v4` resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
