### PR TITLE
get-dotnet-version: expose version breakdown outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,18 @@ Outputs (17 commits since the `VersionPrefix` line changed):
 steps.version.outputs.version          - 4.0.17   (5.0.0-beta.17 with VersionSuffix=beta)
 steps.version.outputs.assembly-version - 4.0.0.0
 steps.version.outputs.file-version     - 4.0.17.0
+steps.version.outputs.major            - 4
+steps.version.outputs.minor            - 0
 steps.version.outputs.patch            - 17
+steps.version.outputs.version-suffix   -          (e.g. "beta" for a prerelease line)
+steps.version.outputs.is-prerelease    - false    (true when a VersionSuffix is set)
+```
+
+The breakdown lets a workflow branch on the parts — e.g. gate publishing to stable trunk builds and
+prereleases only:
+
+```yaml
+    if: github.ref == 'refs/heads/main' || steps.version.outputs.is-prerelease == 'true'
 ```
 
 ## Releasing

--- a/get-dotnet-version/GetVersion.ps1
+++ b/get-dotnet-version/GetVersion.ps1
@@ -31,11 +31,15 @@ else {
 $assemblyVersion = "$Major.0.0.0"
 $fileVersion = "$Major.$Minor.$count.0"
 
+$isPrerelease = if ($suffix) { 'true' } else { 'false' }
+
 Write-Output "Version is $version (assembly $assemblyVersion, file $fileVersion)"
 
 "version=$version" >> $Env:GITHUB_OUTPUT
 "assembly-version=$assemblyVersion" >> $Env:GITHUB_OUTPUT
 "file-version=$fileVersion" >> $Env:GITHUB_OUTPUT
 "patch=$count" >> $Env:GITHUB_OUTPUT
+"version-suffix=$suffix" >> $Env:GITHUB_OUTPUT
+"is-prerelease=$isPrerelease" >> $Env:GITHUB_OUTPUT
 
 Write-Output "::notice::Version $version (assembly $assemblyVersion)"

--- a/get-dotnet-version/action.yml
+++ b/get-dotnet-version/action.yml
@@ -5,7 +5,8 @@ description: >-
   the patch is the number of commits since that version line last changed (so unrelated
   edits to the props file do not reset it). Set VersionSuffix for a prerelease line.
   Requires a full-history checkout (fetch-depth: 0) and the .NET SDK on the runner.
-  Outputs Version, AssemblyVersion (Major.0.0.0) and FileVersion.
+  Outputs the full Version, AssemblyVersion (Major.0.0.0) and FileVersion, plus a breakdown
+  (major, minor, patch, version-suffix, is-prerelease) so callers can branch on the parts.
 inputs:
   project:
     description: 'MSBuild file that declares VersionPrefix (and optionally VersionSuffix)'
@@ -32,6 +33,18 @@ outputs:
   file-version:
     description: 'File version, Major.Minor.patch.0'
     value: ${{ steps.assemble.outputs.file-version }}
+  major:
+    description: 'The major version, from VersionPrefix'
+    value: ${{ steps.major-minor.outputs.major }}
+  minor:
+    description: 'The minor version, from VersionPrefix'
+    value: ${{ steps.major-minor.outputs.minor }}
   patch:
     description: 'The computed patch (commit count since the version line changed)'
     value: ${{ steps.assemble.outputs.patch }}
+  version-suffix:
+    description: 'The prerelease suffix from VersionSuffix (e.g. beta), or empty for a stable version'
+    value: ${{ steps.assemble.outputs.version-suffix }}
+  is-prerelease:
+    description: 'true when a VersionSuffix is present (prerelease), otherwise false'
+    value: ${{ steps.assemble.outputs.is-prerelease }}


### PR DESCRIPTION
Exposes a version **breakdown** from `get-dotnet-version` so consumers can branch on the parts instead of string-matching the composed semver.

## New outputs
Alongside the existing `version` / `assembly-version` / `file-version` / `patch`:
- `major`, `minor` — from `VersionPrefix` (surfaced from the inner `get-version-number-from-project`).
- `version-suffix` — the `VersionSuffix` (e.g. `beta`), empty for a stable version.
- `is-prerelease` — `true` when a `VersionSuffix` is present, else `false`.

## Why
ASM's build gates publishing to "the stable trunk or a prerelease build". It currently infers that with `contains(version, '-')`; with this change it can use the first-class `is-prerelease` output. Verified locally: stable props → `version-suffix=` / `is-prerelease=false`.

No behavioural change to existing outputs. After merge + a release (move `v4`), I'll switch ASM to `is-prerelease`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
