### PR TITLE
Add get-node-version action (stated-version strategy for npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,85 @@ prereleases only:
     if: github.ref == 'refs/heads/main' || steps.version.outputs.is-prerelease == 'true'
 ```
 
+## Get Node Version
+
+The Node counterpart of [Get .NET Version](#get-net-version). Derives an npm package version from
+`package.json` where **the version is stated, not inferred**: `Major.Minor` (and an optional
+prerelease suffix) come from the `version` field, and the patch is the number of commits **since
+that version line last changed** (so unrelated edits to `package.json` don't reset it). State a
+prerelease line by stating e.g. `5.0.0-beta`. `package.json`'s `version` plays the role that
+`VersionPrefix`/`VersionSuffix` play in `Directory.Build.props` — only `Major.Minor` and the
+optional `-suffix` are authoritative; the stated patch is ignored and recomputed. Requires a
+full-history checkout (`fetch-depth: 0`).
+
+### Example
+
+Given `package.json`:
+
+```json
+{
+  "name": "example",
+  "version": "4.0.0"
+}
+```
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0          # required: full history for the commit count
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        registry-url: "https://npm.pkg.github.com"
+    - name: Get version
+      id: version
+      uses: andrewmclachlan/actions/get-node-version@v4
+      with:
+        package-file: 'package.json'   # optional, this is the default
+    - run: npm ci
+    - run: npm pkg set version=${{ steps.version.outputs.version }}
+    - run: npm run build
+    # Publish only from main (the stable trunk) or a prerelease line (a branch whose stated
+    # version carries a suffix). A suffix-less non-main branch publishes nothing.
+    - if: github.ref == 'refs/heads/main' || steps.version.outputs.is-prerelease == 'true'
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: npm publish
+```
+
+Outputs (17 commits since the `version` line changed):
+
+```
+steps.version.outputs.version        - 4.0.17   (5.0.0-beta.17 when version is 5.0.0-beta)
+steps.version.outputs.major          - 4
+steps.version.outputs.minor          - 0
+steps.version.outputs.patch          - 17
+steps.version.outputs.suffix         -          (beta when version is 5.0.0-beta)
+steps.version.outputs.is-prerelease  - false    (true when a suffix is present)
+```
+
+For a monorepo, apply the version to every published workspace, e.g.
+`npm pkg set version=${{ steps.version.outputs.version }} --workspace=pkg-a --workspace=pkg-b`.
+
+### Branching
+
+Same model as .NET, with the version living in `package.json` *on the branch* — every branch is
+self-describing and isolated, no shared tags:
+
+- **`main` is the trunk** — every merge publishes `X.Y.<count>` (stable).
+- **`feature/*` / PRs** build and test but never publish.
+- **A preview line is a `release/**` branch whose stated version carries a suffix** — e.g. on
+  `release/5.0-beta` set `"version": "5.0.0-beta"` → publishes `5.0.0-beta.N` while `main` stays on
+  `4.x`. Graduate **in place**: remove the suffix (`"version": "5.0.0"`, which publishes nothing off
+  `main`), merge to `main`, and `main` publishes `5.0.0`.
+
 ## Releasing
 
 This repo publishes reusable actions that consumers reference by tag (e.g. `andrewmclachlan/actions/set-version-number@v4`). Releases follow the **moving major tag** convention: alongside an immutable full version tag (`v4.5`, `v4.5.2`), a `v<MAJOR>` tag (`v4`) is kept pointing at the latest release in that major line. Consumers pin `@v4` and automatically pick up the newest `v4.x`.

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ steps.version.outputs.version        - 4.0.17   (5.0.0-beta.17 when version is 5
 steps.version.outputs.major          - 4
 steps.version.outputs.minor          - 0
 steps.version.outputs.patch          - 17
-steps.version.outputs.suffix         -          (beta when version is 5.0.0-beta)
+steps.version.outputs.version-suffix -          (beta when version is 5.0.0-beta)
 steps.version.outputs.is-prerelease  - false    (true when a suffix is present)
 ```
 

--- a/get-node-version/GetVersion.ps1
+++ b/get-node-version/GetVersion.ps1
@@ -1,0 +1,60 @@
+param (
+    [Parameter(Mandatory = $false)]
+    [string]$PackageFile = 'package.json'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $PackageFile)) {
+    throw "Package file '$PackageFile' not found."
+}
+
+# The version is *stated*, not inferred. Only Major.Minor and the optional prerelease
+# suffix are authoritative; the patch is computed from the commit count below.
+$stated = (Get-Content -Path $PackageFile -Raw | ConvertFrom-Json).version
+if (-not $stated) {
+    throw "Could not find a 'version' field in '$PackageFile'."
+}
+
+Write-Output "Read stated version '$stated' from $PackageFile"
+
+# Split off an optional prerelease suffix (e.g. 5.0.0-beta -> core '5.0.0', suffix 'beta').
+$core, $suffix = $stated -split '-', 2
+
+$parts = $core -split '\.'
+$major = $parts[0]
+$minor = $parts[1]
+
+if ($major -notmatch '^\d+$' -or $minor -notmatch '^\d+$') {
+    throw "Stated version '$stated' is not a valid Major.Minor version."
+}
+
+# Patch = commits since the version LINE last changed. -G'"version":' matches only commits whose
+# diff touched a line containing the "version": key, so other edits to package.json are ignored.
+$set = (git log -1 --format=%H '-G"version":' -- $PackageFile 2>$null | Out-String).Trim()
+if ($set) {
+    $patch = (git rev-list --count "$set..HEAD" | Out-String).Trim()
+}
+else {
+    $patch = (git rev-list --count HEAD | Out-String).Trim()
+}
+
+if ($suffix) {
+    $version = "$major.$minor.0-$suffix.$patch"
+    $isPrerelease = 'true'
+}
+else {
+    $version = "$major.$minor.$patch"
+    $isPrerelease = 'false'
+}
+
+Write-Output "Version is $version"
+
+"version=$version"             >> $Env:GITHUB_OUTPUT
+"major=$major"                 >> $Env:GITHUB_OUTPUT
+"minor=$minor"                 >> $Env:GITHUB_OUTPUT
+"patch=$patch"                 >> $Env:GITHUB_OUTPUT
+"suffix=$suffix"               >> $Env:GITHUB_OUTPUT
+"is-prerelease=$isPrerelease"  >> $Env:GITHUB_OUTPUT
+
+Write-Output "::notice::Version $version"

--- a/get-node-version/GetVersion.ps1
+++ b/get-node-version/GetVersion.ps1
@@ -54,7 +54,7 @@ Write-Output "Version is $version"
 "major=$major"                 >> $Env:GITHUB_OUTPUT
 "minor=$minor"                 >> $Env:GITHUB_OUTPUT
 "patch=$patch"                 >> $Env:GITHUB_OUTPUT
-"suffix=$suffix"               >> $Env:GITHUB_OUTPUT
+"version-suffix=$suffix"       >> $Env:GITHUB_OUTPUT
 "is-prerelease=$isPrerelease"  >> $Env:GITHUB_OUTPUT
 
 Write-Output "::notice::Version $version"

--- a/get-node-version/action.yml
+++ b/get-node-version/action.yml
@@ -30,9 +30,9 @@ outputs:
   patch:
     description: 'The computed patch (commit count since the version line changed)'
     value: ${{ steps.get-version.outputs.patch }}
-  suffix:
+  version-suffix:
     description: 'The prerelease suffix (e.g. beta), or empty for a stable line'
-    value: ${{ steps.get-version.outputs.suffix }}
+    value: ${{ steps.get-version.outputs.version-suffix }}
   is-prerelease:
     description: 'true when a prerelease suffix is present, otherwise false'
     value: ${{ steps.get-version.outputs.is-prerelease }}

--- a/get-node-version/action.yml
+++ b/get-node-version/action.yml
@@ -1,0 +1,38 @@
+name: 'Get Node version'
+author: 'Andrew McLachlan'
+description: >-
+  Derive an npm package version from package.json where the version is stated, not inferred:
+  Major.Minor (and an optional prerelease suffix) come from the "version" field, and the patch
+  is the number of commits since that version line last changed (so unrelated edits to
+  package.json do not reset it). Set a prerelease suffix by stating e.g. 5.0.0-beta.
+  Requires a full-history checkout (fetch-depth: 0).
+inputs:
+  package-file:
+    description: 'package.json file that declares the stated Major.Minor[-suffix] version'
+    default: 'package.json'
+    required: false
+runs:
+  using: composite
+  steps:
+    - id: get-version
+      shell: pwsh
+      run: ${{ github.action_path }}/GetVersion.ps1 -PackageFile '${{ inputs.package-file }}'
+outputs:
+  version:
+    description: 'Full package version, e.g. 4.0.17 (stable) or 5.0.0-beta.4 (prerelease)'
+    value: ${{ steps.get-version.outputs.version }}
+  major:
+    description: 'The major version number'
+    value: ${{ steps.get-version.outputs.major }}
+  minor:
+    description: 'The minor version number'
+    value: ${{ steps.get-version.outputs.minor }}
+  patch:
+    description: 'The computed patch (commit count since the version line changed)'
+    value: ${{ steps.get-version.outputs.patch }}
+  suffix:
+    description: 'The prerelease suffix (e.g. beta), or empty for a stable line'
+    value: ${{ steps.get-version.outputs.suffix }}
+  is-prerelease:
+    description: 'true when a prerelease suffix is present, otherwise false'
+    value: ${{ steps.get-version.outputs.is-prerelease }}


### PR DESCRIPTION
Implements the [release-branching strategy](https://github.com/AndrewMcLachlan/Asm/blob/main/docs/release-branching-strategy.md) **adapted for Node** — the npm counterpart of `get-dotnet-version`. The version is **stated, not inferred**: no GitVersion, no tags, no version-bump ceremony.

## What it does
- **`Major.Minor`** (and an optional prerelease suffix) come from `package.json`'s `version` field — `package.json` plays the role `Directory.Build.props`'s `VersionPrefix`/`VersionSuffix` play for .NET. Only `Major.Minor` and the optional `-suffix` are authoritative; the stated patch is recomputed.
- **Patch = commits since the `version` line last changed** (`git log -1 --format=%H -G'"version":'`), so unrelated edits to `package.json` don't reset it.
- Stable → `Major.Minor.<count>`; prerelease (state e.g. `5.0.0-beta`) → `Major.Minor.0-<suffix>.<count>`.
- **Outputs** `version`, `major`, `minor`, `patch`, `suffix`, `is-prerelease` so consumers can gate publishing to `main` + prerelease lines (`release/**` branches whose stated version carries a suffix).

Composite action (`pwsh` script), mirroring `get-dotnet-version`'s structure. Requires `fetch-depth: 0`.

## Verification
Ran `GetVersion.ps1` against real repos:
- Stable: `"version": "4.0.0"` → `4.0.322` (322 = commits since the version line changed; total history is ~1448, proving the `-G` scoping — an unrelated `package.json` edit does **not** reset the patch).
- Prerelease: `"version": "5.0.0-beta"` → `5.0.0-beta.<count>`, `suffix=beta`, `is-prerelease=true`.

`action.yml` parses cleanly; README updated with a gated npm-publish example and the branching model.

## Follow-up (separate repo, not in this PR)
The Node library that motivated this — **MooApp** — still uses GitVersion in its `build.yml`. Adopting this action there (and dropping GitVersion) is the consumer-side change; happy to raise that PR against `AndrewMcLachlan/MooApp` next if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)