### PR TITLE
Don't move the major tag for draft/prerelease; add Publish Release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,122 @@
+name: Publish Release
+
+# Publishes a draft release created by the Release workflow: creates its
+# immutable version tag, marks the release as published, and advances the
+# moving major tag (vMAJOR) to that commit — unless the release is a prerelease.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Draft tag to publish (optional; defaults to the most recent draft)'
+        type: string
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Find draft release
+        id: draft
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ -n "$REQUESTED_TAG" ]]; then
+            TAG="$REQUESTED_TAG"
+          else
+            TAG=$(gh release list --json tagName,isDraft,createdAt --limit 100 \
+              | jq -r '[.[] | select(.isDraft)] | sort_by(.createdAt) | last | .tagName // empty')
+          fi
+
+          if [[ -z "$TAG" ]]; then
+            echo "::error::No draft release found to publish."
+            exit 1
+          fi
+
+          INFO=$(gh release view "$TAG" --json isDraft,isPrerelease,targetCommitish)
+          if [[ "$(jq -r '.isDraft' <<<"$INFO")" != "true" ]]; then
+            echo "::error::Release '$TAG' is not a draft."
+            exit 1
+          fi
+
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+){1,2}$ ]]; then
+            echo "::error::Invalid tag '$TAG'. Expected vMAJOR.MINOR or vMAJOR.MINOR.PATCH."
+            exit 1
+          fi
+
+          MAJOR_TAG="v$(echo "${TAG#v}" | cut -d. -f1)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "major_tag=$MAJOR_TAG" >> "$GITHUB_OUTPUT"
+          echo "sha=$(jq -r '.targetCommitish' <<<"$INFO")" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$(jq -r '.isPrerelease' <<<"$INFO")" >> "$GITHUB_OUTPUT"
+          echo "Publishing draft $TAG (prerelease=$(jq -r '.isPrerelease' <<<"$INFO"))"
+
+      - name: Configure git user
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create version tag
+        shell: bash
+        env:
+          TAG: ${{ steps.draft.outputs.tag }}
+          SHA: ${{ steps.draft.outputs.sha }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag '$TAG' already exists. Version tags are immutable and will not be overwritten."
+            exit 1
+          fi
+          git fetch --no-tags origin "$SHA" 2>/dev/null || true
+          git tag -a "$TAG" -m "Release $TAG" "$SHA"
+          git push origin "refs/tags/$TAG"
+          echo "Created and pushed version tag $TAG at $SHA"
+
+      - name: Publish the draft release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.draft.outputs.tag }}
+        run: |
+          gh release edit "$TAG" --draft=false
+          echo "Published release $TAG"
+
+      # Advance the moving major tag only for a stable (non-prerelease) release.
+      - name: Move major tag
+        if: steps.draft.outputs.is_prerelease != 'true'
+        shell: bash
+        env:
+          MAJOR_TAG: ${{ steps.draft.outputs.major_tag }}
+          TAG: ${{ steps.draft.outputs.tag }}
+          SHA: ${{ steps.draft.outputs.sha }}
+        run: |
+          git tag -d "$MAJOR_TAG" 2>/dev/null || true
+          git push origin ":refs/tags/$MAJOR_TAG" 2>/dev/null || true
+          git tag -a "$MAJOR_TAG" -m "Update $MAJOR_TAG to $TAG" "$SHA"
+          git push --force origin "refs/tags/$MAJOR_TAG"
+          echo "Moved major tag $MAJOR_TAG to $SHA"
+
+      - name: Summary
+        shell: bash
+        env:
+          TAG: ${{ steps.draft.outputs.tag }}
+          MAJOR_TAG: ${{ steps.draft.outputs.major_tag }}
+          SHA: ${{ steps.draft.outputs.sha }}
+          IS_PRERELEASE: ${{ steps.draft.outputs.is_prerelease }}
+        run: |
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            echo "::notice::Published prerelease $TAG at $SHA ($MAJOR_TAG not moved)."
+          else
+            echo "::notice::Published $TAG and moved $MAJOR_TAG to $SHA."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # Drafts don't get an immutable version tag yet — it's created when the
+      # draft is published (see the Publish Release workflow), so abandoning a
+      # draft doesn't orphan a tag that would block re-cutting the version.
       - name: Create version tag
+        if: ${{ !inputs.draft }}
         shell: bash
         env:
           TAG: ${{ steps.vars.outputs.tag }}
@@ -65,7 +69,11 @@ jobs:
           git push origin "refs/tags/$TAG"
           echo "Created and pushed version tag $TAG at $SHA"
 
+      # The moving major tag only advances for a published, stable release —
+      # never for a draft or prerelease, so consumers pinning @vMAJOR don't pick
+      # up an unpublished or pre-release commit.
       - name: Move major tag
+        if: ${{ !inputs.draft && !inputs.prerelease }}
         shell: bash
         env:
           MAJOR_TAG: ${{ steps.vars.outputs.major_tag }}
@@ -102,5 +110,13 @@ jobs:
           TAG: ${{ steps.vars.outputs.tag }}
           MAJOR_TAG: ${{ steps.vars.outputs.major_tag }}
           SHA: ${{ github.sha }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          DRAFT: ${{ inputs.draft }}
         run: |
-          echo "::notice::Released $TAG, moved $MAJOR_TAG to $SHA"
+          if [[ "$DRAFT" == "true" ]]; then
+            echo "::notice::Created draft release $TAG (no tags created or moved). Run the Publish Release workflow to publish it and move $MAJOR_TAG."
+          elif [[ "$PRERELEASE" == "true" ]]; then
+            echo "::notice::Released prerelease $TAG at $SHA (version tag created; $MAJOR_TAG not moved)."
+          else
+            echo "::notice::Released $TAG and moved $MAJOR_TAG to $SHA."
+          fi

--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ To cut a release:
 The workflow will:
 
 - Validate the tag format and derive the major tag (`v4.5` → `v4`).
-- Create the annotated full version tag at the dispatched commit and push it. It **fails** if that exact version tag already exists (version tags are immutable).
-- Delete and recreate the major tag `v<MAJOR>` at the same commit, force-pushing it so `@v4` moves forward.
 - Create a GitHub Release for the version tag with auto-generated notes, honouring the `prerelease`/`draft` inputs.
+- **Tag according to what kind of release it is:**
+  - **Stable** (not draft, not prerelease): create the annotated version tag at the dispatched commit, and move the major tag `v<MAJOR>` to it (force-push, so `@v4` advances). Fails if the version tag already exists (version tags are immutable).
+  - **Prerelease** (published): create the version tag, but **do not move the major tag** — consumers on `@v4` won't pick up a prerelease.
+  - **Draft**: create only the draft release — **no tags are created or moved**. The version tag and major-tag move happen when you publish it (below), so abandoning a draft leaves nothing behind.
+
+### Publishing a draft
+
+Use **Actions → Publish Release → Run workflow** to publish a draft cut above. With no input it publishes the **most recent draft**; optionally pass a specific draft `tag`. It will:
+
+- Create the annotated version tag at the draft's target commit and push it.
+- Publish the release (clears the draft flag).
+- Move the major tag `v<MAJOR>` to that commit — **unless the draft is a prerelease**, in which case the major tag stays put.


### PR DESCRIPTION
The Release workflow moved the moving major tag (`vMAJOR`, e.g. `v4`) **unconditionally** — so cutting a draft or prerelease would advance `@v4` and push an unpublished/pre-release commit onto everyone pinning `@v4`.

## `release.yml` — tagging is now conditional
| Kind | Version tag (`v4.5`) | Major tag (`v4`) |
|------|:---:|:---:|
| **Stable** (not draft, not prerelease) | created | **moved** |
| **Prerelease** (published) | created | *not moved* |
| **Draft** | *not created* | *not moved* |

A draft now creates **only** the draft release — no git tags. So the version tag + major-tag move happen when the draft is **published** (below), and abandoning a draft leaves no orphan tag that would block re-cutting that version.

## `publish-release.yml` — new
Publishes a draft cut by the Release workflow, doing the tagging **at that point**:
- Finds the **most recent draft** (or an optional specific `tag` input).
- Creates the annotated version tag at the draft's target commit.
- Clears the draft flag (`gh release edit --draft=false`).
- Moves the major tag to that commit — **unless the draft is a prerelease**.

## Verification
Both workflows parse as valid YAML. Gates:
- `release.yml` → Create version tag: `${{ !inputs.draft }}`; Move major tag: `${{ !inputs.draft && !inputs.prerelease }}`
- `publish-release.yml` → Move major tag: `steps.draft.outputs.is_prerelease != 'true'`

README "Releasing" section updated with the conditional tagging and a "Publishing a draft" subsection.

## Testing note
`release.yml` is already registered on `main`, so the **modified** version can be dry-run from this branch (Actions → Release → Run workflow → pick this branch). `publish-release.yml` is new, so GitHub won't surface its **Run workflow** button until it's on the default branch — it can only be exercised after merge. Its tag steps mirror the existing, working `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)