### PR TITLE
Always create the version tag; only gate the major tag

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,8 +1,9 @@
 name: Publish Release
 
-# Publishes a draft release created by the Release workflow: creates its
-# immutable version tag, marks the release as published, and advances the
-# moving major tag (vMAJOR) to that commit — unless the release is a prerelease.
+# Publishes a draft release created by the Release workflow and advances the
+# moving major tag (vMAJOR) to that release's commit — unless it's a prerelease.
+# The immutable version tag (e.g. v4.5) already exists (created when the draft
+# was cut); this workflow just publishes and moves the major tag "at that point".
 
 on:
   workflow_dispatch:
@@ -44,7 +45,7 @@ jobs:
             exit 1
           fi
 
-          INFO=$(gh release view "$TAG" --json isDraft,isPrerelease,targetCommitish)
+          INFO=$(gh release view "$TAG" --json isDraft,isPrerelease)
           if [[ "$(jq -r '.isDraft' <<<"$INFO")" != "true" ]]; then
             echo "::error::Release '$TAG' is not a draft."
             exit 1
@@ -55,10 +56,8 @@ jobs:
             exit 1
           fi
 
-          MAJOR_TAG="v$(echo "${TAG#v}" | cut -d. -f1)"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "major_tag=$MAJOR_TAG" >> "$GITHUB_OUTPUT"
-          echo "sha=$(jq -r '.targetCommitish' <<<"$INFO")" >> "$GITHUB_OUTPUT"
+          echo "major_tag=v$(echo "${TAG#v}" | cut -d. -f1)" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=$(jq -r '.isPrerelease' <<<"$INFO")" >> "$GITHUB_OUTPUT"
           echo "Publishing draft $TAG (prerelease=$(jq -r '.isPrerelease' <<<"$INFO"))"
 
@@ -67,21 +66,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Create version tag
-        shell: bash
-        env:
-          TAG: ${{ steps.draft.outputs.tag }}
-          SHA: ${{ steps.draft.outputs.sha }}
-        run: |
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "::error::Tag '$TAG' already exists. Version tags are immutable and will not be overwritten."
-            exit 1
-          fi
-          git fetch --no-tags origin "$SHA" 2>/dev/null || true
-          git tag -a "$TAG" -m "Release $TAG" "$SHA"
-          git push origin "refs/tags/$TAG"
-          echo "Created and pushed version tag $TAG at $SHA"
 
       - name: Publish the draft release
         shell: bash
@@ -92,31 +76,37 @@ jobs:
           gh release edit "$TAG" --draft=false
           echo "Published release $TAG"
 
-      # Advance the moving major tag only for a stable (non-prerelease) release.
+      # Advance the moving major tag to the same commit as the version tag, but
+      # only for a stable (non-prerelease) release.
       - name: Move major tag
         if: steps.draft.outputs.is_prerelease != 'true'
         shell: bash
         env:
           MAJOR_TAG: ${{ steps.draft.outputs.major_tag }}
           TAG: ${{ steps.draft.outputs.tag }}
-          SHA: ${{ steps.draft.outputs.sha }}
         run: |
+          # Resolve the commit the (now-published) version tag points to.
+          git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"
+          SHA=$(git rev-list -n1 "refs/tags/$TAG")
+          if [[ -z "$SHA" ]]; then
+            echo "::error::Could not resolve a commit for tag $TAG."
+            exit 1
+          fi
           git tag -d "$MAJOR_TAG" 2>/dev/null || true
           git push origin ":refs/tags/$MAJOR_TAG" 2>/dev/null || true
           git tag -a "$MAJOR_TAG" -m "Update $MAJOR_TAG to $TAG" "$SHA"
           git push --force origin "refs/tags/$MAJOR_TAG"
-          echo "Moved major tag $MAJOR_TAG to $SHA"
+          echo "Moved major tag $MAJOR_TAG to $SHA (= $TAG)"
 
       - name: Summary
         shell: bash
         env:
           TAG: ${{ steps.draft.outputs.tag }}
           MAJOR_TAG: ${{ steps.draft.outputs.major_tag }}
-          SHA: ${{ steps.draft.outputs.sha }}
           IS_PRERELEASE: ${{ steps.draft.outputs.is_prerelease }}
         run: |
           if [[ "$IS_PRERELEASE" == "true" ]]; then
-            echo "::notice::Published prerelease $TAG at $SHA ($MAJOR_TAG not moved)."
+            echo "::notice::Published prerelease $TAG ($MAJOR_TAG not moved)."
           else
-            echo "::notice::Published $TAG and moved $MAJOR_TAG to $SHA."
+            echo "::notice::Published $TAG and moved $MAJOR_TAG to it."
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      # Drafts don't get an immutable version tag yet — it's created when the
-      # draft is published (see the Publish Release workflow), so abandoning a
-      # draft doesn't orphan a tag that would block re-cutting the version.
+      # The immutable version tag (e.g. v4.5) is always created — consumers must
+      # explicitly opt into it, so it never changes an existing @vMAJOR workflow.
       - name: Create version tag
-        if: ${{ !inputs.draft }}
         shell: bash
         env:
           TAG: ${{ steps.vars.outputs.tag }}
@@ -114,7 +112,7 @@ jobs:
           DRAFT: ${{ inputs.draft }}
         run: |
           if [[ "$DRAFT" == "true" ]]; then
-            echo "::notice::Created draft release $TAG (no tags created or moved). Run the Publish Release workflow to publish it and move $MAJOR_TAG."
+            echo "::notice::Created draft release $TAG with version tag $TAG ($MAJOR_TAG not moved). Run the Publish Release workflow to publish it and move $MAJOR_TAG."
           elif [[ "$PRERELEASE" == "true" ]]; then
             echo "::notice::Released prerelease $TAG at $SHA (version tag created; $MAJOR_TAG not moved)."
           else

--- a/README.md
+++ b/README.md
@@ -278,16 +278,13 @@ To cut a release:
 The workflow will:
 
 - Validate the tag format and derive the major tag (`v4.5` → `v4`).
+- Create the annotated version tag at the dispatched commit and push it. It **fails** if that exact version tag already exists (version tags are immutable).
 - Create a GitHub Release for the version tag with auto-generated notes, honouring the `prerelease`/`draft` inputs.
-- **Tag according to what kind of release it is:**
-  - **Stable** (not draft, not prerelease): create the annotated version tag at the dispatched commit, and move the major tag `v<MAJOR>` to it (force-push, so `@v4` advances). Fails if the version tag already exists (version tags are immutable).
-  - **Prerelease** (published): create the version tag, but **do not move the major tag** — consumers on `@v4` won't pick up a prerelease.
-  - **Draft**: create only the draft release — **no tags are created or moved**. The version tag and major-tag move happen when you publish it (below), so abandoning a draft leaves nothing behind.
+- **Move the major tag `v<MAJOR>` to the commit — but only for a published, stable release.** For a **prerelease** or a **draft**, the major tag is left where it is, so consumers pinning `@v4` never get pulled onto an unpublished or pre-release commit. (The immutable version tag *is* always created — you have to explicitly opt into `@v4.5`, so it can never change an existing `@v4` workflow.)
 
 ### Publishing a draft
 
-Use **Actions → Publish Release → Run workflow** to publish a draft cut above. With no input it publishes the **most recent draft**; optionally pass a specific draft `tag`. It will:
+A draft already has its version tag (e.g. `v4.5`) — it just isn't published, and `@v4` hasn't moved to it. Use **Actions → Publish Release → Run workflow** to finish it: with no input it publishes the **most recent draft** (optionally pass a specific `tag`). It will:
 
-- Create the annotated version tag at the draft's target commit and push it.
-- Publish the release (clears the draft flag).
-- Move the major tag `v<MAJOR>` to that commit — **unless the draft is a prerelease**, in which case the major tag stays put.
+- Publish the release (clear the draft flag).
+- Move the major tag `v<MAJOR>` to the version tag's commit — **unless the draft is a prerelease**, in which case `@v4` stays put.


### PR DESCRIPTION
Follow-up correction to #31 (already merged). #31 stopped drafts from creating their version tag; per review that's not wanted — the immutable version tag (e.g. `v4.5`) is fine to create for drafts and prereleases because consumers must **explicitly** opt into `@v4.5`, so it can never change an existing `@vMAJOR` workflow. **Only the moving major tag** must not advance for a draft or prerelease.

## Changes
- **`release.yml`**: the version tag is created **unconditionally** again (dropped the `if: ${{ !inputs.draft }}`). Only the major-tag move stays gated on `!draft && !prerelease`.
- **`publish-release.yml`**: since a draft already has its version tag, publishing just clears the draft flag and moves the major tag to the version tag's commit (unless prerelease) — no version-tag creation step.
- **README**: the only conditional documented is now the major tag.

## Net behaviour
| Kind | Version tag (`v4.5`) | Major tag (`v4`) |
|------|:---:|:---:|
| Stable | created | **moved** |
| Prerelease | created | *not moved* |
| Draft | created | *not moved* (moves on publish) |

Both workflows parse as valid YAML; the only remaining conditions are the major-tag moves (`release.yml`: `!inputs.draft && !inputs.prerelease`; `publish-release.yml`: `is_prerelease != 'true'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)